### PR TITLE
Fix material helper to allow patterns of structure materials/x/nn-y/nn-z.ext

### DIFF
--- a/index.js
+++ b/index.js
@@ -551,7 +551,7 @@ var registerHelpers = function () {
 
 		// remove leading numbers from name keyword
 		// partials are always registered with the leading numbers removed
-		var key = name.replace(/(\d+[\-\.])+/, '');
+		var key = name.replace(/(\d+[\-\.])+/g, '');
 
 		// attempt to find pre-compiled partial
 		var template = Handlebars.partials[key],

--- a/test/expected/index.html
+++ b/test/expected/index.html
@@ -81,6 +81,16 @@
 		</form>
 	</div>
 
+	<h1>Elements</h1>
+
+	<h2>Headings</h2>
+
+	<h3>H1</h3>
+
+	<div class="item">
+		<h1>Heading Level 1</h1>
+	</div>
+
     <script src="assets/scripts/main.js"></script>
 
 </body>

--- a/test/expected/material-key.html
+++ b/test/expected/material-key.html
@@ -28,6 +28,11 @@
 		<h2>Form</h2>
 
 
+	<h1>Elements</h1>
+
+		<h2>Headings</h2>
+
+
 	<h1>Pages</h1>
 
 		<h2>Home</h2>

--- a/test/fixtures/materials/elements/00-headings/00-h1.html
+++ b/test/fixtures/materials/elements/00-headings/00-h1.html
@@ -1,0 +1,1 @@
+<h1>Heading Level 1</h1>


### PR DESCRIPTION
Assuming `options.keys.materials` is set to `materials`,
When you have a materials directory with the following structure:

```
└── materials
    └── non-numeric-parent
        └── 00-with-a-numeric-subcategory
            └── 00-and-a-numeric-material.hbs
```

And try to use the [`{{material}}`](https://github.com/fbrctr/fabricator/blob/v1.2.3/src/views/layouts/includes/f-item-content.html#L7) helper when [iterating](https://github.com/fbrctr/fabricator/blob/v1.2.3/src/views/layouts/includes/f-menu.html#L12) over `materials.non-numeric-parent.items` using `@key` to reference the name of the material you're referencing, it will resolve incorrectly.

`@key` ends up being `00-with-a-numeric-subcategory.00-and-a-numeric-material`, and the [`replace`](https://github.com/fbrctr/fabricator-assemble/blob/v1.1.11/index.js#L554) only ends up replacing the first instance of the regex, leaving you with an invalid partial (in this case, `with-a-numeric-subcategory.00-and-a-numeric-material`).

Adding `/g` will replace both of these instances, resulting in the correct partial name and resolution.
