### PR TITLE
Perform additional replace to get correct key in material helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -551,7 +551,7 @@ var registerHelpers = function () {
 
 		// remove leading numbers from name keyword
 		// partials are always registered with the leading numbers removed
-		var key = name.replace(/(\d+[\-\.])+/g, '');
+		var key = name.replace(/^(\d+[\-\.])+/, '').replace(/\.(\d+[\-\.])+/g, '.');
 
 		// attempt to find pre-compiled partial
 		var template = Handlebars.partials[key],


### PR DESCRIPTION
Now works correctly with:

```
non-numeric-sub/dir/00-test.ext
non-numeric-sub/dir/00.01-bar.ext
non-numeric-sub/dir/00.01-bas.00.ext
non-numeric-sub/dir/00.01-bat-00.ext
non-numeric-sub/dir/baz.ext
non-numeric-sub/dir/numeric-baz.80.ext
non-numeric-sub/dir/numeric-hyphen-baz-90.ext
```

and 

```
numeric-sub/00-dir/00-test.ext
numeric-sub/00-dir/00.01-bar.ext
numeric-sub/00-dir/00.01-bas.00.ext
numeric-sub/00-dir/00.01-bat-00.ext
numeric-sub/00-dir/baz.ext
numeric-sub/00-dir/numeric-baz.80.ext
numeric-sub/00-dir/numeric-hyphen-baz-90.ext
```
